### PR TITLE
Redesigned API for merkle proofs verification

### DIFF
--- a/lib/merkle_tree/proof.ex
+++ b/lib/merkle_tree/proof.ex
@@ -55,11 +55,10 @@ defmodule MerkleTree.Proof do
   end
 
   @doc false
+  @deprecated "Use proven?/4 instead"
   # TODO: remove when deprecated MerkleTree.Proof.proven?/3 support ends
   def proven?({block, index}, root_hash,
               %MerkleTree.Proof{hashes: proof, hash_function: hash_function}) do
-    IO.warn "MerkleTree.Proof.proven?/3 is deprecated. " <>
-            "Use MerkleTree.Proof.proven?/4 instead."
     height = length(proof)
     root_hash == _hash_proof(block, binarize(index, height), proof, hash_function)
   end

--- a/lib/merkle_tree/proof.ex
+++ b/lib/merkle_tree/proof.ex
@@ -16,6 +16,7 @@ defmodule MerkleTree.Proof do
 
   @type t :: %MerkleTree.Proof{
     hashes: [String.t, ...],
+    # TODO: remove when deprecated MerkleTree.Proof.proven?/3 support ends
     hash_function: MerkleTree.hash_function
   }
 
@@ -27,6 +28,7 @@ defmodule MerkleTree.Proof do
             index) do
     %MerkleTree.Proof{
       hashes: _prove(root, binarize(index, height)),
+      # TODO: remove when deprecated MerkleTree.Proof.proven?/3 support ends
       hash_function: tree.hash_function
     }
   end
@@ -45,9 +47,19 @@ defmodule MerkleTree.Proof do
   @doc """
   Verifies proof for a block at a specific index
   """
-  @spec proven?({String.t, non_neg_integer}, String.t, t) :: boolean
+  @spec proven?({String.t, non_neg_integer}, String.t, MerkleTree.hash_function, t) :: boolean
+  def proven?({block, index}, root_hash, hash_function,
+              %MerkleTree.Proof{hashes: proof}) do
+    height = length(proof)
+    root_hash == _hash_proof(block, binarize(index, height), proof, hash_function)
+  end
+
+  @doc false
+  # TODO: remove when deprecated MerkleTree.Proof.proven?/3 support ends
   def proven?({block, index}, root_hash,
               %MerkleTree.Proof{hashes: proof, hash_function: hash_function}) do
+    IO.warn "MerkleTree.Proof.proven?/3 is deprecated. " <>
+            "Use MerkleTree.Proof.proven?/4 instead."
     height = length(proof)
     root_hash == _hash_proof(block, binarize(index, height), proof, hash_function)
   end

--- a/test/merkle_tree/proof_test.exs
+++ b/test/merkle_tree/proof_test.exs
@@ -15,11 +15,66 @@ defmodule MerkleTree.ProofTest do
     assert blocks
     |> Enum.with_index
     |> Enum.zip(proofs)
+    |> Enum.map(fn {x, proof} -> proven?(x, tree.root.value, tree.hash_function, proof) end)
+    |> Enum.all?
+  end
+
+  # TODO: remove when deprecated MerkleTree.Proof.proven?/3 support ends
+  test "correct proofs with deprecated proven?/3" do
+    blocks = ~w/a b c d e f g h/
+    tree = MerkleTree.new blocks
+
+    proofs = blocks
+    |> Enum.with_index
+    |> Enum.map(fn {_, idx} -> prove(tree, idx) end)
+
+    assert blocks
+    |> Enum.with_index
+    |> Enum.zip(proofs)
     |> Enum.map(fn {x, proof} -> proven?(x, tree.root.value, proof) end)
     |> Enum.all?
   end
 
+  
   test "incorrect proof" do
+    blocks = ~w/a b c d e f g h/
+    tree = MerkleTree.new blocks
+    %MerkleTree.Proof{hashes: hashes} = proof = prove(tree, 5)
+
+    # test sanity
+    assert proven?({"f", 5}, tree.root.value, tree.hash_function, proof)
+
+    # bad index
+    assert not proven?({"f", 6}, tree.root.value, tree.hash_function, proof)
+
+    incomplete_proof = %MerkleTree.Proof{
+      hashes: tl(hashes),
+      hash_function: tree.hash_function
+    }
+    assert not proven?({"f", 5}, tree.root.value, tree.hash_function, incomplete_proof)
+
+    # different hash function
+    assert not proven?({"f", 5}, tree.root.value, &(MerkleTree.Crypto.hash(&1, :sha224)), proof)
+
+    corrupted_proof = %MerkleTree.Proof{
+      hashes: [tree.hash_function.("z")] ++ tl(hashes),
+      hash_function: tree.hash_function
+    }
+    assert not proven?({"f", 5}, tree.root.value, tree.hash_function, corrupted_proof)
+
+    # corrupted root hash
+    assert not proven?({"f", 5}, tree.hash_function.("z"), tree.hash_function, proof)
+
+    # fake proof rejected with proven?/4
+    fake_proof = %MerkleTree.Proof{
+      hashes: Enum.map(hashes, fn _ -> "" end),
+      hash_function: fn _ -> tree.root.value end
+    }
+    assert not proven?({"z", 5}, tree.root.value, tree.hash_function, fake_proof)
+  end
+
+  # TODO: remove when deprecated MerkleTree.Proof.proven?/3 support ends
+  test "incorrect proof with deprecated proven?/3" do
     blocks = ~w/a b c d e f g h/
     tree = MerkleTree.new blocks
     %MerkleTree.Proof{hashes: hashes} = proof = prove(tree, 5)
@@ -50,6 +105,13 @@ defmodule MerkleTree.ProofTest do
 
     # corrupted root hash
     assert not proven?({"f", 5}, tree.hash_function.("z"), proof)
+
+    # fake proof accepted with deprecated proven?/3
+    fake_proof = %MerkleTree.Proof{
+      hashes: Enum.map(hashes, fn _ -> "" end),
+      hash_function: fn _ -> tree.root.value end
+    }
+    assert proven?({"z", 5}, tree.root.value, fake_proof)
   end
 
 end


### PR DESCRIPTION
Hi, I would like to suggest a subtle yet important change in the interface of MerkleTree.Proof.

Hash function choice is fixed when given merkle tree is generated.
It should not be possible for anyone who claims a data block is correct to choose other hash function for proof verification.
It is easy to forge a fake proof if arbitrary function can be chosen (illustrated by test).

To address above issue, `MerkleTree.Proof.proven?/3` has been marked as deprecated and `MerkleTree.Proof.proven?/4` has been introduced.
The new function does not rely on `hash_function` that is part of `proof`, but rather on `hash_function` passed as explicit parameter.
