### PR TITLE
fixed misleading flag hash_leaf -> hash_leaves

### DIFF
--- a/lib/merkle_tree.ex
+++ b/lib/merkle_tree.ex
@@ -39,9 +39,9 @@ defmodule MerkleTree do
      available options:
       :hash_function - used hash in mercle tree default :sha256 from :cryto
       :hash_leaves - flag says whether the leaves should be hashed, default true
-      :height - allows to construct tree of provided height, 
+      :height - allows to construct tree of provided height,
           empty leaves data will be taken from `:default_data_block` parameter
-      :default_data_block - this data will be used to supply empty 
+      :default_data_block - this data will be used to supply empty
           leaves in case where there isn't enough blocks provided
   Check out `MerkleTree.Crypto` for other available cryptographic hashes.
   Alternatively, you can supply your own hash function that has the spec
@@ -59,7 +59,7 @@ defmodule MerkleTree do
       fill_blocks(blocks, Keyword.get(opts, :default_data_block), Keyword.get(opts, :height))
 
     leaves =
-      if Keyword.get(opts, :hash_leaf, true),
+      if Keyword.get(opts, :hash_leaves, true),
         do: Enum.map(blocks, hash_function),
         else: blocks
 

--- a/test/merkle_tree_test.exs
+++ b/test/merkle_tree_test.exs
@@ -29,7 +29,7 @@ defmodule MerkleTreeTest do
     blocks = ['a', 'a', 'a', 'a']
 
     assert MerkleTree.new(blocks).root ==
-             MerkleTree.new(blocks |> Enum.map(&MerkleTree.Crypto.sha256/1), hash_leaf: false).root
+             MerkleTree.new(blocks |> Enum.map(&MerkleTree.Crypto.sha256/1), hash_leaves: false).root
   end
 
   test "default hash function sha256" do


### PR DESCRIPTION
Hey, just spotted - @doc says `hash_leaves` but actual flag is `hash_leaf` 
Thanks for accepting this silly change :D