### PR TITLE
Speed up merkle root/tree/proof calculation + formatting + dialyzer

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,8 @@
+# Used by "mix format"
+[
+  inputs: [
+    "mix.exs",
+    "{lib,test,config}/**/*.{ex,exs}"
+  ],
+  line_length: 120
+]

--- a/lib/merkle_tree.ex
+++ b/lib/merkle_tree.ex
@@ -68,7 +68,7 @@ defmodule MerkleTree do
 
   See `new/2` for a rundown of options
   """
-  @spec fast_root(blocks, Keyword.t()) :: root
+  @spec fast_root(blocks, Keyword.t()) :: MerkleTree.Node.hash()
   def fast_root(blocks, opts \\ []) do
     {hash_function, height, hash_leaves?, default_data_block} = get_from_options(opts, blocks)
 
@@ -115,7 +115,7 @@ defmodule MerkleTree do
 
   See `new/2` for a rundown of options
   """
-  @spec build(blocks, hash_function) :: root
+  @spec build(blocks, hash_function | Keyword.t()) :: root
   def build(blocks, hash_function_or_opts \\ [])
 
   def build(blocks, hash_function) when is_function(hash_function),

--- a/lib/merkle_tree.ex
+++ b/lib/merkle_tree.ex
@@ -35,7 +35,7 @@ defmodule MerkleTree do
         }
 
   @doc """
-    Creates a new merkle tree, given a blocks and hash function or opts
+    Creates a new merkle tree, given a blocks and hash function or opts.
      available options:
       :hash_function - used hash in mercle tree default :sha256 from :cryto
       :hash_leaves - flag says whether the leaves should be hashed, default true
@@ -47,82 +47,130 @@ defmodule MerkleTree do
   Alternatively, you can supply your own hash function that has the spec
   ``(String.t -> String.t)``.
   """
-  @spec new(blocks, hash_function | list({atom, any})) :: t
+  @spec new(blocks, hash_function | Keyword.t()) :: t
+  def new(blocks, hash_function_or_opts \\ [])
 
   def new(blocks, hash_function) when is_function(hash_function),
     do: new(blocks, hash_function: hash_function)
 
-  def new(blocks, opts \\ []) when is_list(opts) do
+  def new(blocks, opts) when is_list(opts) do
+    # fill in the data blocks, note we don't allow to fill in with in with a sensible default here, like ""
+    filled_blocks = fill_blocks(blocks, Keyword.get(opts, :default_data_block), Keyword.get(opts, :height))
+    # calculate the root node, which does all the hashing etc.
+    root = build(blocks, opts)
+
     hash_function = Keyword.get(opts, :hash_function, &MerkleTree.Crypto.sha256/1)
-
-    blocks = fill_blocks(blocks, Keyword.get(opts, :default_data_block), Keyword.get(opts, :height))
-
-    leaves =
-      if Keyword.get(opts, :hash_leaves, true),
-        do: Enum.map(blocks, hash_function),
-        else: blocks
-
-    nodes =
-      Enum.map(leaves, fn block ->
-        %MerkleTree.Node{
-          value: block,
-          children: [],
-          height: 0
-        }
-      end)
-
-    root = _build(nodes, hash_function, 0)
-    %MerkleTree{blocks: blocks, hash_function: hash_function, root: root}
+    %MerkleTree{blocks: filled_blocks, hash_function: hash_function, root: root}
   end
 
   @doc """
-    Builds a new binary merkle tree.
+  Calculates the root of the merkle tree without building the entire tree explicitly,
+
+  See `new/2` for a rundown of options
   """
-  @spec build(blocks, hash_function) :: root
-  def build(blocks, hash_function) do
-    starting_height = 0
+  @spec fast_root(blocks, Keyword.t()) :: root
+  def fast_root(blocks, opts \\ []) do
+    {hash_function, height, hash_leaves?, default_data_block} = get_from_options(opts, blocks)
 
-    leaves =
-      Enum.map(blocks, fn block ->
-        %MerkleTree.Node{
-          value: hash_function.(block),
-          children: [],
-          height: starting_height
-        }
-      end)
+    default_leaf_value = if hash_leaves?, do: hash_function.(default_data_block), else: default_data_block
+    leaf_values = if hash_leaves?, do: Enum.map(blocks, hash_function), else: blocks
 
-    _build(leaves, hash_function, starting_height)
+    _fast_root(leaf_values, hash_function, 0, default_leaf_value, height)
   end
 
-  # Base case
-  defp _build([root], _, _), do: root
-  # Recursive case
-  defp _build(nodes, hash_function, previous_height) do
-    children_partitions = Enum.chunk(nodes, @number_of_children)
-    height = previous_height + 1
+  defp _fast_root([], hash_function, height, default_leaf, final_height),
+    do: _fast_root([default_leaf], hash_function, height, default_leaf, final_height)
+
+  defp _fast_root([root], _, final_height, _, final_height), do: root
+
+  defp _fast_root(nodes, hash_function, height, default_leaf, final_height) do
+    count = step = @number_of_children
+    leftover = List.duplicate(default_leaf, count - 1)
+    children_partitions = Enum.chunk_every(nodes, count, step, leftover)
+    new_height = height + 1
 
     parents =
       Enum.map(children_partitions, fn partition ->
-        concatenated_values =
-          partition
-          |> Enum.map(& &1.value)
-          |> Enum.reduce("", fn x, acc -> acc <> x end)
+        concatenated_values = partition |> Enum.join()
+        hash_function.(concatenated_values)
+      end)
+
+    new_default_leaf_value = hash_function.(default_leaf <> default_leaf)
+
+    _fast_root(parents, hash_function, new_height, new_default_leaf_value, final_height)
+  end
+
+  # takes care of the defaults etc
+  defp get_from_options(opts, blocks) do
+    {
+      Keyword.get(opts, :hash_function, &MerkleTree.Crypto.sha256/1),
+      Keyword.get(opts, :height, guess_height(Enum.count(blocks))),
+      Keyword.get(opts, :hash_leaves, true),
+      Keyword.get(opts, :default_data_block, "")
+    }
+  end
+
+  @doc """
+  Builds a root MerkleTree.Node structure of a merkle tree
+
+  See `new/2` for a rundown of options
+  """
+  @spec build(blocks, hash_function) :: root
+  def build(blocks, hash_function_or_opts \\ [])
+
+  def build(blocks, hash_function) when is_function(hash_function),
+    do: build(blocks, hash_function: hash_function)
+
+  def build(blocks, opts) do
+    {hash_function, height, hash_leaves?, default_data_block} = get_from_options(opts, blocks)
+
+    default_leaf_value = if hash_leaves?, do: hash_function.(default_data_block), else: default_data_block
+    leaf_values = if hash_leaves?, do: Enum.map(blocks, hash_function), else: blocks
+    default_leaf = %MerkleTree.Node{value: default_leaf_value, children: [], height: 0}
+    leaves = Enum.map(leaf_values, &%MerkleTree.Node{value: &1, children: [], height: 0})
+
+    _build(leaves, hash_function, 0, default_leaf, height)
+  end
+
+  defp _build([], hash_function, height, default_leaf, final_height),
+    do: _build([default_leaf], hash_function, height, default_leaf, final_height)
+
+  # Base case
+  defp _build([root], _, final_height, _, final_height), do: root
+  # Recursive case
+  defp _build(nodes, hash_function, height, default_leaf, final_height) do
+    count = step = @number_of_children
+    leftover = List.duplicate(default_leaf, count - 1)
+    children_partitions = Enum.chunk_every(nodes, count, step, leftover)
+    new_height = height + 1
+
+    parents =
+      Enum.map(children_partitions, fn partition ->
+        concatenated_values = partition |> Enum.map(& &1.value) |> Enum.join()
 
         %MerkleTree.Node{
           value: hash_function.(concatenated_values),
           children: partition,
-          height: height
+          height: new_height
         }
       end)
 
-    _build(parents, hash_function, height)
+    new_default_leaf_value = hash_function.(default_leaf.value <> default_leaf.value)
+
+    new_default_leaf = %MerkleTree.Node{
+      value: new_default_leaf_value,
+      children: List.duplicate(default_leaf, @number_of_children),
+      height: new_height
+    }
+
+    _build(parents, hash_function, new_height, new_default_leaf, final_height)
   end
 
   defp _ceil(a), do: if(a > trunc(a), do: trunc(a) + 1, else: trunc(a))
 
   defp fill_blocks(blocks, default, nil) when default != nil do
     blocks_count = Enum.count(blocks)
-    leaves_count = :math.pow(2, _ceil(:math.log2(blocks_count)))
+    leaves_count = guess_leaves_count(blocks_count)
     blocks ++ List.duplicate(default, trunc(leaves_count - blocks_count))
   end
 
@@ -142,4 +190,8 @@ defmodule MerkleTree do
       do: raise(MerkleTree.ArgumentError),
       else: blocks
   end
+
+  defp guess_leaves_count(blocks_count), do: :math.pow(2, guess_height(blocks_count))
+  defp guess_height(0), do: 0
+  defp guess_height(blocks_count), do: _ceil(:math.log2(blocks_count))
 end

--- a/lib/merkle_tree/crypto.ex
+++ b/lib/merkle_tree/crypto.ex
@@ -6,12 +6,12 @@ defmodule MerkleTree.Crypto do
 
   @type algorithm :: :md5 | :sha | :sha224 | :sha256 | :sha384 | :sha512
 
-  @spec sha256(String.t) :: String.t
+  @spec sha256(String.t()) :: String.t()
   def sha256(data) do
     hash(data, :sha256)
   end
 
-  @spec hash(String.t, algorithm) :: String.t
+  @spec hash(String.t(), algorithm) :: String.t()
   def hash(data, algorithm) do
     :crypto.hash(algorithm, data) |> Base.encode16(case: :lower)
   end

--- a/lib/merkle_tree/error.ex
+++ b/lib/merkle_tree/error.ex
@@ -1,3 +1,3 @@
 defmodule MerkleTree.ArgumentError do
-  defexception message: "MerkleTree.new requires a power of 2 (2^N) number of blocks." 
+  defexception message: "MerkleTree.new requires a power of 2 (2^N) number of blocks."
 end

--- a/lib/merkle_tree/node.ex
+++ b/lib/merkle_tree/node.ex
@@ -5,8 +5,10 @@ defmodule MerkleTree.Node do
 
   defstruct [:value, :children, :height]
 
+  @type hash :: binary() | String.t()
+
   @type t :: %__MODULE__{
-          value: String.t(),
+          value: hash(),
           children: [MerkleTree.Node.t()],
           height: non_neg_integer
         }

--- a/lib/merkle_tree/node.ex
+++ b/lib/merkle_tree/node.ex
@@ -6,8 +6,8 @@ defmodule MerkleTree.Node do
   defstruct [:value, :children, :height]
 
   @type t :: %__MODULE__{
-    value: String.t,
-    children: [MerkleTree.Node.t],
-    height: non_neg_integer
-  }
+          value: String.t(),
+          children: [MerkleTree.Node.t()],
+          height: non_neg_integer
+        }
 end

--- a/lib/merkle_tree/proof.ex
+++ b/lib/merkle_tree/proof.ex
@@ -15,17 +15,19 @@ defmodule MerkleTree.Proof do
   defstruct [:hashes, :hash_function]
 
   @type t :: %MerkleTree.Proof{
-    hashes: [String.t, ...],
-    # TODO: remove when deprecated MerkleTree.Proof.proven?/3 support ends
-    hash_function: MerkleTree.hash_function
-  }
+          hashes: [String.t(), ...],
+          # TODO: remove when deprecated MerkleTree.Proof.proven?/3 support ends
+          hash_function: MerkleTree.hash_function()
+        }
 
   @doc """
   Generates proof for a block at a specific index
   """
-  @spec prove(MerkleTree.t, non_neg_integer) :: t
-  def prove(%MerkleTree{root: %MerkleTree.Node{height: height} = root} = tree,
-            index) do
+  @spec prove(MerkleTree.t(), non_neg_integer) :: t
+  def prove(
+        %MerkleTree{root: %MerkleTree.Node{height: height} = root} = tree,
+        index
+      ) do
     %MerkleTree.Proof{
       hashes: _prove(root, binarize(index, height)),
       # TODO: remove when deprecated MerkleTree.Proof.proven?/3 support ends
@@ -34,22 +36,27 @@ defmodule MerkleTree.Proof do
   end
 
   defp _prove(_, ""), do: []
-  defp _prove(%MerkleTree.Node{children: children},
-              index_binary) do
+
+  defp _prove(
+         %MerkleTree.Node{children: children},
+         index_binary
+       ) do
     {path_head, path_tail} = path_from_binary(index_binary)
-    [child, sibling] = case path_head do
-      1 -> Enum.reverse(children)
-      0 -> children
-    end
+
+    [child, sibling] =
+      case path_head do
+        1 -> Enum.reverse(children)
+        0 -> children
+      end
+
     [sibling.value] ++ _prove(child, path_tail)
   end
 
   @doc """
   Verifies proof for a block at a specific index
   """
-  @spec proven?({String.t, non_neg_integer}, String.t, MerkleTree.hash_function, t) :: boolean
-  def proven?({block, index}, root_hash, hash_function,
-              %MerkleTree.Proof{hashes: proof}) do
+  @spec proven?({String.t(), non_neg_integer}, String.t(), MerkleTree.hash_function(), t) :: boolean
+  def proven?({block, index}, root_hash, hash_function, %MerkleTree.Proof{hashes: proof}) do
     height = length(proof)
     root_hash == _hash_proof(block, binarize(index, height), proof, hash_function)
   end
@@ -57,8 +64,7 @@ defmodule MerkleTree.Proof do
   @doc false
   @deprecated "Use proven?/4 instead"
   # TODO: remove when deprecated MerkleTree.Proof.proven?/3 support ends
-  def proven?({block, index}, root_hash,
-              %MerkleTree.Proof{hashes: proof, hash_function: hash_function}) do
+  def proven?({block, index}, root_hash, %MerkleTree.Proof{hashes: proof, hash_function: hash_function}) do
     height = length(proof)
     root_hash == _hash_proof(block, binarize(index, height), proof, hash_function)
   end
@@ -66,15 +72,13 @@ defmodule MerkleTree.Proof do
   defp _hash_proof(block, "", [], hash_function) do
     hash_function.(block)
   end
+
   defp _hash_proof(block, index_binary, [proof_head | proof_tail], hash_function) do
     {path_head, path_tail} = path_from_binary(index_binary)
+
     case path_head do
-      1 -> hash_function.(
-        proof_head <> _hash_proof(block, path_tail, proof_tail, hash_function)
-      )
-      0 -> hash_function.(
-        _hash_proof(block, path_tail, proof_tail, hash_function) <> proof_head
-      )
+      1 -> hash_function.(proof_head <> _hash_proof(block, path_tail, proof_tail, hash_function))
+      0 -> hash_function.(_hash_proof(block, path_tail, proof_tail, hash_function) <> proof_head)
     end
   end
 
@@ -86,8 +90,7 @@ defmodule MerkleTree.Proof do
 
   @spec path_from_binary(binary) :: {binary, binary}
   defp path_from_binary(index_binary) do
-    <<path_head::unsigned-big-integer-unit(1)-size(1),
-    path_tail::binary-unit(1)>> = index_binary
+    <<path_head::unsigned-big-integer-unit(1)-size(1), path_tail::binary-unit(1)>> = index_binary
     {path_head, path_tail}
   end
 end

--- a/lib/merkle_tree/proof.ex
+++ b/lib/merkle_tree/proof.ex
@@ -17,7 +17,7 @@ defmodule MerkleTree.Proof do
   @type t :: %MerkleTree.Proof{
           hashes: [String.t(), ...],
           # TODO: remove when deprecated MerkleTree.Proof.proven?/3 support ends
-          hash_function: MerkleTree.hash_function()
+          hash_function: MerkleTree.hash_function() | nil
         }
 
   @doc """
@@ -78,13 +78,13 @@ defmodule MerkleTree.Proof do
     end
   end
 
-  @spec binarize(integer, integer) :: binary
+  @spec binarize(integer, integer) :: bitstring
   defp binarize(index, height) do
     <<index_binary::binary-unit(1)>> = <<index::unsigned-big-integer-size(height)>>
     index_binary
   end
 
-  @spec path_from_binary(binary) :: {binary, binary}
+  @spec path_from_binary(bitstring) :: {0 | 1, bitstring}
   defp path_from_binary(index_binary) do
     <<path_head::unsigned-big-integer-unit(1)-size(1), path_tail::binary-unit(1)>> = index_binary
     {path_head, path_tail}

--- a/lib/merkle_tree/proof.ex
+++ b/lib/merkle_tree/proof.ex
@@ -23,17 +23,13 @@ defmodule MerkleTree.Proof do
   @doc """
   Generates proof for a block at a specific index
   """
-  @spec prove(MerkleTree.t(), non_neg_integer) :: t
-  def prove(
-        %MerkleTree{root: %MerkleTree.Node{height: height} = root} = tree,
-        index
-      ) do
-    %MerkleTree.Proof{
-      hashes: _prove(root, binarize(index, height)),
-      # TODO: remove when deprecated MerkleTree.Proof.proven?/3 support ends
-      hash_function: tree.hash_function
-    }
-  end
+  @spec prove(MerkleTree.t() | MerkleTree.Node.t(), non_neg_integer) :: t
+  def prove(%MerkleTree{root: root} = tree, index),
+    # TODO: remove the struct update with hash function, when deprecated MerkleTree.Proof.proven?/3 support ends
+    do: %MerkleTree.Proof{prove(root, index) | hash_function: tree.hash_function}
+
+  def prove(%MerkleTree.Node{height: height} = root, index),
+    do: %MerkleTree.Proof{hashes: _prove(root, binarize(index, height))}
 
   defp _prove(_, ""), do: []
 

--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,7 @@ defmodule MerkleTree.Mixfile do
     [
       {:ex_doc, "~> 0.11", only: :dev},
       {:earmark, "~> 0.1", only: :dev},
-      {:dialyxir, "~> 0.3", only: :dev},
+      {:dialyxir, "~> 1.0.0-rc.4", only: [:dev, :test], runtime: false},
       {:excoveralls, "~> 0.5", only: :test}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -2,15 +2,17 @@ defmodule MerkleTree.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :merkle_tree,
-     version: "1.5.0",
-     elixir: "~> 1.2",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     description: description(),
-     package: package(),
-     deps: deps(),
-     test_coverage: [tool: ExCoveralls]]
+    [
+      app: :merkle_tree,
+      version: "1.5.0",
+      elixir: "~> 1.2",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      description: description(),
+      package: package(),
+      deps: deps(),
+      test_coverage: [tool: ExCoveralls]
+    ]
   end
 
   # Configuration for the OTP application
@@ -28,14 +30,12 @@ defmodule MerkleTree.Mixfile do
 
   defp package() do
     [
-     files: ["lib", "mix.exs", "README.md"],
-     maintainers: ["Yos Riady"],
-     licenses: ["MIT"],
-     links: %{"GitHub" => "https://github.com/yosriady/merkle_tree",
-              "Docs" => "http://hexdocs.pm/merkle_tree/"}
-     ]
+      files: ["lib", "mix.exs", "README.md"],
+      maintainers: ["Yos Riady"],
+      licenses: ["MIT"],
+      links: %{"GitHub" => "https://github.com/yosriady/merkle_tree", "Docs" => "http://hexdocs.pm/merkle_tree/"}
+    ]
   end
-
 
   def application do
     [applications: [:logger]]
@@ -51,9 +51,11 @@ defmodule MerkleTree.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps() do
-    [{:ex_doc, "~> 0.11", only: :dev},
-     {:earmark, "~> 0.1", only: :dev},
-     {:dialyxir, "~> 0.3", only: :dev},
-     {:excoveralls, "~> 0.5", only: :test}]
+    [
+      {:ex_doc, "~> 0.11", only: :dev},
+      {:earmark, "~> 0.1", only: :dev},
+      {:dialyxir, "~> 0.3", only: :dev},
+      {:excoveralls, "~> 0.5", only: :test}
+    ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,8 @@
-%{"certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
-  "dialyxir": {:hex, :dialyxir, "0.3.3", "2f8bb8ab4e17acf4086cae847bd385c0f89296d3e3448dc304c26bfbe4b46cb4", [:mix], []},
+%{
+  "certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
+  "dialyxir": {:hex, :dialyxir, "1.0.0-rc.6", "78e97d9c0ff1b5521dd68041193891aebebce52fc3b93463c0a6806874557d7d", [:mix], [{:erlex, "~> 0.2.1", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
+  "erlex": {:hex, :erlex, "0.2.1", "cee02918660807cbba9a7229cae9b42d1c6143b768c781fa6cee1eaf03ad860b", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
   "excoveralls": {:hex, :excoveralls, "0.5.4", "1a6e116bcf980da8b7fe33140c1d7e61aa0a4e51951cadbfacc420c12d2b9b8f", [:mix], [{:hackney, ">= 0.12.0", [hex: :hackney, optional: false]}, {:exjsx, "~> 3.0", [hex: :exjsx, optional: false]}]},
   "exjsx": {:hex, :exjsx, "3.2.0", "7136cc739ace295fc74c378f33699e5145bead4fdc1b4799822d0287489136fb", [:mix], [{:jsx, "~> 2.6.2", [hex: :jsx, optional: false]}]},
@@ -9,4 +11,5 @@
   "jsx": {:hex, :jsx, "2.6.2", "213721e058da0587a4bce3cc8a00ff6684ced229c8f9223245c6ff2c88fbaa5a", [:mix, :rebar], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []}}
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
+}

--- a/test/merkle_tree/proof_test.exs
+++ b/test/merkle_tree/proof_test.exs
@@ -6,39 +6,40 @@ defmodule MerkleTree.ProofTest do
 
   test "correct proofs" do
     blocks = ~w/a b c d e f g h/
-    tree = MerkleTree.new blocks
+    tree = MerkleTree.new(blocks)
 
-    proofs = blocks
-    |> Enum.with_index
-    |> Enum.map(fn {_, idx} -> prove(tree, idx) end)
+    proofs =
+      blocks
+      |> Enum.with_index()
+      |> Enum.map(fn {_, idx} -> prove(tree, idx) end)
 
     assert blocks
-    |> Enum.with_index
-    |> Enum.zip(proofs)
-    |> Enum.map(fn {x, proof} -> proven?(x, tree.root.value, tree.hash_function, proof) end)
-    |> Enum.all?
+           |> Enum.with_index()
+           |> Enum.zip(proofs)
+           |> Enum.map(fn {x, proof} -> proven?(x, tree.root.value, tree.hash_function, proof) end)
+           |> Enum.all?()
   end
 
   # TODO: remove when deprecated MerkleTree.Proof.proven?/3 support ends
   test "correct proofs with deprecated proven?/3" do
     blocks = ~w/a b c d e f g h/
-    tree = MerkleTree.new blocks
+    tree = MerkleTree.new(blocks)
 
-    proofs = blocks
-    |> Enum.with_index
-    |> Enum.map(fn {_, idx} -> prove(tree, idx) end)
+    proofs =
+      blocks
+      |> Enum.with_index()
+      |> Enum.map(fn {_, idx} -> prove(tree, idx) end)
 
     assert blocks
-    |> Enum.with_index
-    |> Enum.zip(proofs)
-    |> Enum.map(fn {x, proof} -> proven?(x, tree.root.value, proof) end)
-    |> Enum.all?
+           |> Enum.with_index()
+           |> Enum.zip(proofs)
+           |> Enum.map(fn {x, proof} -> proven?(x, tree.root.value, proof) end)
+           |> Enum.all?()
   end
 
-  
   test "incorrect proof" do
     blocks = ~w/a b c d e f g h/
-    tree = MerkleTree.new blocks
+    tree = MerkleTree.new(blocks)
     %MerkleTree.Proof{hashes: hashes} = proof = prove(tree, 5)
 
     # test sanity
@@ -51,15 +52,17 @@ defmodule MerkleTree.ProofTest do
       hashes: tl(hashes),
       hash_function: tree.hash_function
     }
+
     assert not proven?({"f", 5}, tree.root.value, tree.hash_function, incomplete_proof)
 
     # different hash function
-    assert not proven?({"f", 5}, tree.root.value, &(MerkleTree.Crypto.hash(&1, :sha224)), proof)
+    assert not proven?({"f", 5}, tree.root.value, &MerkleTree.Crypto.hash(&1, :sha224), proof)
 
     corrupted_proof = %MerkleTree.Proof{
       hashes: [tree.hash_function.("z")] ++ tl(hashes),
       hash_function: tree.hash_function
     }
+
     assert not proven?({"f", 5}, tree.root.value, tree.hash_function, corrupted_proof)
 
     # corrupted root hash
@@ -70,13 +73,14 @@ defmodule MerkleTree.ProofTest do
       hashes: Enum.map(hashes, fn _ -> "" end),
       hash_function: fn _ -> tree.root.value end
     }
+
     assert not proven?({"z", 5}, tree.root.value, tree.hash_function, fake_proof)
   end
 
   # TODO: remove when deprecated MerkleTree.Proof.proven?/3 support ends
   test "incorrect proof with deprecated proven?/3" do
     blocks = ~w/a b c d e f g h/
-    tree = MerkleTree.new blocks
+    tree = MerkleTree.new(blocks)
     %MerkleTree.Proof{hashes: hashes} = proof = prove(tree, 5)
 
     # test sanity
@@ -89,18 +93,21 @@ defmodule MerkleTree.ProofTest do
       hashes: tl(hashes),
       hash_function: tree.hash_function
     }
+
     assert not proven?({"f", 5}, tree.root.value, incomplete_proof)
 
     different_hash = %MerkleTree.Proof{
       hashes: hashes,
-      hash_function: &(MerkleTree.Crypto.hash(&1, :sha224))
+      hash_function: &MerkleTree.Crypto.hash(&1, :sha224)
     }
+
     assert not proven?({"f", 5}, tree.root.value, different_hash)
 
     corrupted_proof = %MerkleTree.Proof{
       hashes: [tree.hash_function.("z")] ++ tl(hashes),
       hash_function: tree.hash_function
     }
+
     assert not proven?({"f", 5}, tree.root.value, corrupted_proof)
 
     # corrupted root hash
@@ -111,7 +118,7 @@ defmodule MerkleTree.ProofTest do
       hashes: Enum.map(hashes, fn _ -> "" end),
       hash_function: fn _ -> tree.root.value end
     }
+
     assert proven?({"z", 5}, tree.root.value, fake_proof)
   end
-
 end

--- a/test/merkle_tree_test.exs
+++ b/test/merkle_tree_test.exs
@@ -6,13 +6,29 @@ defmodule MerkleTreeTest do
     assert_raise(FunctionClauseError, fn -> MerkleTree.new([]) end)
   end
 
-  test "invalid block size" do
+  test "valid empty blocks when default given" do
+    assert %MerkleTree{} = MerkleTree.new([], default_data_block: "")
+  end
+
+  test "invalid block size and no default data" do
     assert_raise(MerkleTree.ArgumentError, fn -> MerkleTree.new(["a", "b", "c"]) end)
   end
 
   test "primary use case" do
     f = MerkleTree.new(['a', 'b', 'c', 'd'])
     assert f.root.value == "58c89d709329eb37285837b042ab6ff72c7c8f74de0446b091b6a0131c102cfd"
+  end
+
+  test "ability to calculate tree in varying flavours of the builder functions equivalently" do
+    assertions = fn blocks ->
+      assert MerkleTree.build(blocks, height: 2).value == MerkleTree.fast_root(blocks, height: 2)
+      assert MerkleTree.build(blocks).value == MerkleTree.fast_root(blocks)
+      assert MerkleTree.new(blocks, height: 2, default_data_block: "").root == MerkleTree.build(blocks, height: 2)
+      assert MerkleTree.new(blocks, default_data_block: "").root == MerkleTree.build(blocks)
+    end
+
+    [['a', 'b', 'c', 'd'], ['a', 'b', 'c'], ['a', 'b'], ['a'], []]
+    |> Enum.map(assertions)
   end
 
   test "default data block with height" do


### PR DESCRIPTION
Hi, we noticed that calculating merkle tree roots and proofs is underperforming in `v1.5.0` for some larger-sized cases.

The reason was that the `default_leaf` filling in and hashing (for fixed-height trees mainly) was doing a lot of unnecessary work.

We have had some prior versions of the optimized code, but this time the attempt is aiming at keeping the existing APIs and behaviors intact (note there are only cosmetic updates to tests).

In details, this PR mainly introduces the `fast_root` function, which calculates the merkle root without going into building of the tree structure per se. Other optimization is now that building of the `blocks` array within `MerkleTree` is facultative and decoupled from calculating of the tree itself. Next, the same approach to options used for `new` had been applied to `blocks` and `fast_root`, so that all of these entry-points act on par. Old versions are kept for compatibility. 

Lastly, we provide the ability to calculate the merkle proof using a `MerkleTree.Node` only, also allowing us to speed things up.

I'm also smuggling 2 things into this PR:

 - `mix format` formatting in (in a separate commit for easy reviewing: `style: add and apply formatter`) . 
 - bumping and fixing some dialyzer issues (`fix: bump dialyxir and fix dialyzer woes`)

I hope it's a forgivable short-cut. The proper changes are in `feat: speed up new and also provide fast_root for fastest merkling`.

